### PR TITLE
Fix: bash train_lora.sh argument position error

### DIFF
--- a/huggingface_interface/train_lora.sh
+++ b/huggingface_interface/train_lora.sh
@@ -3,9 +3,9 @@ export CUDA_VISIBLE_DEVICES=0
 data_dir=${1:-"en-indic-exp"}
 model_name=${2:-"ai4bharat/indictrans2-en-indic-dist-200M"}
 output_dir=${3:-"output"}
-direction=${3:-"en-indic"}
-src_lang_list=${4:-"eng_Latn"}
-tgt_lang_list=${5:-"asm_Beng,ben_Beng,guj_Gujr,hin_Deva,kan_Knda,mal_Mlym,mar_Deva,npi_Deva,ory_Orya,pan_Guru,tam_Taml,tel_Telu,urd_Arab"}
+direction=${4:-"en-indic"}
+src_lang_list=${5:-"eng_Latn"}
+tgt_lang_list=${6:-"asm_Beng,ben_Beng,guj_Gujr,hin_Deva,kan_Knda,mal_Mlym,mar_Deva,npi_Deva,ory_Orya,pan_Guru,tam_Taml,tel_Telu,urd_Arab"}
 
 python3 train_lora.py \
     --data_dir $data_dir \


### PR DESCRIPTION
train_lora.sh in huggingface interface has 2 arguments with position 3 leading to runtime error on execution